### PR TITLE
Fix installation script path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/ohos-sdk
-        key: ${{ runner.os }}-ohos-sdk-${{ inputs.version }}
+        key: "${{ runner.os }}-ohos-sdk-${{ inputs.version }}"
       if: ${{ inputs.cache == 'true' }}
     - name: Download and install OpenHarmony SDK
       id: install_ohos_sdk

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
       if: ${{ inputs.cache == 'true' }}
     - name: Download and install OpenHarmony SDK
       id: install_ohos_sdk
-      run: ./install_ohos_sdk.sh
+      run: ${{ github.action_path }}/install_ohos_sdk.sh
       shell: bash
       if: ${{ inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true' }}
       env:

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
       if: ${{ inputs.cache == 'true' }}
     - name: Download and install OpenHarmony SDK
       id: install_ohos_sdk
-      run: ${{ github.action_path }}/install_ohos_sdk.sh
+      run: ${{ github.action_path }}install_ohos_sdk.sh
       shell: bash
       if: ${{ inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true' }}
       env:

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,14 @@ runs:
         path: ~/ohos-sdk
         key: "${{ runner.os }}-ohos-sdk-${{ inputs.version }}"
       if: ${{ inputs.cache == 'true' }}
+    - name: Set GitHub Path
+      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+      shell: bash
+      env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
     - name: Download and install OpenHarmony SDK
       id: install_ohos_sdk
-      run: ${{ github.action_path }}install_ohos_sdk.sh
+      run: install_ohos_sdk.sh
       shell: bash
       if: ${{ inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true' }}
       env:


### PR DESCRIPTION
Directly calling `${{ github.action_path }}/install_ohos_sdk.sh` fails on windows, so we need to edit the action path.